### PR TITLE
Restored webpack-dev-server to 2.9.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "vue-template-compiler": "^2.5.2",
     "webpack": "^3.6.0",
     "webpack-bundle-analyzer": "^3.3.2",
-    "webpack-dev-server": "^3.1.11",
+    "webpack-dev-server": "^2.9.7",
     "webpack-merge": "^4.1.0"
   },
   "engines": {


### PR DESCRIPTION
Seems `webpack-dev-server 3.x` has compatibility issues causing `npm run dev` to fail. `2.9.7` used instead.