### PR TITLE
style: use `message` instead of `statusMessage`

### DIFF
--- a/components/custom/CAS/Leave/NewLeaveRequest.vue
+++ b/components/custom/CAS/Leave/NewLeaveRequest.vue
@@ -39,7 +39,7 @@ const { data } = await useAsyncData<AllClubs>('allClubs', () => {
 if (!data.value) {
   throw createError({
     statusCode: 500,
-    statusMessage: '服务器错误',
+    message: '服务器错误',
   })
 }
 

--- a/components/custom/CAS/Leave/ViewMyLeaveRequests.vue
+++ b/components/custom/CAS/Leave/ViewMyLeaveRequests.vue
@@ -27,7 +27,7 @@ watch(() => props.refreshWatcher, () => {
 if (!data.value) {
   throw createError({
     statusCode: 500,
-    statusMessage: '服务器错误',
+    message: '服务器错误',
   })
 }
 </script>

--- a/server/api/bind/confirm.post.ts
+++ b/server/api/bind/confirm.post.ts
@@ -23,7 +23,7 @@ export default defineEventHandler(async (event) => {
   if (!await useStorage().hasItem(requestBody.data.token)) {
     throw createError({
       statusCode: 403,
-      statusMessage: 'Token Incorrect',
+      message: 'Token Incorrect',
     })
   }
 
@@ -32,7 +32,7 @@ export default defineEventHandler(async (event) => {
   if (!storedData) {
     throw createError({
       statusCode: 403,
-      statusMessage: 'Token Incorrect',
+      message: 'Token Incorrect',
     })
   }
 
@@ -43,7 +43,7 @@ export default defineEventHandler(async (event) => {
   }) !== null) {
     throw createError({
       statusCode: 403,
-      statusMessage: 'TSIMS Account already binded',
+      message: 'TSIMS Account already bound',
     })
   }
 

--- a/server/api/bind/index.post.ts
+++ b/server/api/bind/index.post.ts
@@ -39,7 +39,7 @@ export default defineEventHandler(async (event) => {
   if (!await useStorage().hasItem(requestBody.token)) {
     throw createError({
       statusCode: 403,
-      statusMessage: 'Token Incorrect',
+      message: 'Token Incorrect',
     })
   }
 
@@ -48,7 +48,7 @@ export default defineEventHandler(async (event) => {
   if (!storedData) {
     throw createError({
       statusCode: 403,
-      statusMessage: 'Token Incorrect',
+      message: 'Token Incorrect',
     })
   }
 
@@ -72,7 +72,7 @@ export default defineEventHandler(async (event) => {
   if (tsimsLoginResult.status !== 'ok') {
     throw createError({
       statusCode: 403,
-      statusMessage: 'Login Credentials Incorrect',
+      message: 'Login Credentials Incorrect',
     })
   }
 


### PR DESCRIPTION
It was reported that ``[h3] Please prefer using `message` for longer error messages instead of `statusMessage`. In the future, `statusMessage` will be sanitized by default.`` in console while Nuxt was running in certain scenarios.

My other project: #485