### PR TITLE
feat(clubList): search

### DIFF
--- a/pages/cas/clubs/index.vue
+++ b/pages/cas/clubs/index.vue
@@ -46,7 +46,7 @@ const isSearchActive = computed(() => searchTerm.value !== '')
 <template>
   <div>
     <Tabs class="h-full space-y-6" :value="isSearchActive ? '' : undefined" :default-value="isSearchActive ? '' : 'Sports'">
-      <div class="flex justify-between items-center flex-col-reverse ssm:flex-row">
+      <div class="flex flex-col md:flex-row md:items-center md:justify-between">
         <TabsList>
           <TabsTrigger :value="isSearchActive ? '' : 'Sports'" :disabled="isSearchActive">
             Sports
@@ -64,7 +64,7 @@ const isSearchActive = computed(() => searchTerm.value !== '')
             Academic
           </TabsTrigger>
         </TabsList>
-        <Input v-model="searchTerm" type="text" placeholder="Search..." class="float-right max-w-[340px] mb-2 ssm:mb-0 ssm:ml-2" />
+        <Input v-model="searchTerm" type="text" placeholder="Search..." class="float-right w-1/4" />
       </div>
       <TabsContent
         v-for="i in categories"

--- a/pages/cas/clubs/index.vue
+++ b/pages/cas/clubs/index.vue
@@ -47,7 +47,7 @@ const isSearchActive = computed(() => searchTerm.value !== '')
 <template>
   <div>
     <Tabs class="h-full space-y-6" :value="isSearchActive ? '' : undefined" :default-value="isSearchActive ? '' : 'Sports'">
-      <div class="flex flex-col md:flex-row md:items-center md:justify-between">
+      <div class="flex justify-between items-center flex-col-reverse ssm:flex-row">
         <TabsList>
           <TabsTrigger :value="isSearchActive ? '' : 'Sports'" :disabled="isSearchActive">
             Sports
@@ -65,7 +65,7 @@ const isSearchActive = computed(() => searchTerm.value !== '')
             Academic
           </TabsTrigger>
         </TabsList>
-        <Input v-model="searchTerm" type="text" placeholder="Search..." class="float-right w-1/4" />
+        <Input v-model="searchTerm" type="text" placeholder="Search..." class="float-right max-w-[340px] mb-2 ssm:mb-0 ssm:ml-2" />
       </div>
       <TabsContent
         v-for="i in categories"

--- a/pages/cas/clubs/index.vue
+++ b/pages/cas/clubs/index.vue
@@ -46,22 +46,37 @@ const isSearchActive = computed(() => searchTerm.value !== '')
 <template>
   <div>
     <Tabs class="h-full space-y-6" :value="isSearchActive ? '' : undefined" :default-value="isSearchActive ? '' : 'Sports'">
-      <div class="flex flex-col md:flex-row md:items-center md:justify-between">
-        <TabsList>
-          <TabsTrigger :value="isSearchActive ? '' : 'Sports'" :disabled="isSearchActive">
-            Sports
+      <div class="flex flex-row items-center justify-between">
+        <TabsList class="w-min">
+          <TabsTrigger :value="isSearchActive ? '' : 'Sports'" :disabled="isSearchActive" class="flex items-center">
+            <Icon name="material-symbols:sports-basketball" />
+            <div class="hidden sm:block ml-1">
+              Sports
+            </div>
           </TabsTrigger>
-          <TabsTrigger :value="isSearchActive ? '' : 'Service'" :disabled="isSearchActive">
-            Service
+          <TabsTrigger :value="isSearchActive ? '' : 'Service'" :disabled="isSearchActive" class="flex items-center">
+            <Icon name="material-symbols:home-repair-service" />
+            <div class="hidden sm:block ml-1">
+              Service
+            </div>
           </TabsTrigger>
-          <TabsTrigger :value="isSearchActive ? '' : 'Arts'" :disabled="isSearchActive">
-            Arts
+          <TabsTrigger :value="isSearchActive ? '' : 'Arts'" :disabled="isSearchActive" class="flex items-center">
+            <Icon name="material-symbols:format-paint" />
+            <div class="hidden sm:block ml-1">
+              Arts
+            </div>
           </TabsTrigger>
-          <TabsTrigger :value="isSearchActive ? '' : 'Life'" :disabled="isSearchActive">
-            Life
+          <TabsTrigger :value="isSearchActive ? '' : 'Life'" :disabled="isSearchActive" class="flex items-center">
+            <Icon name="material-symbols:nightlife" />
+            <div class="hidden sm:block ml-1">
+              Life
+            </div>
           </TabsTrigger>
-          <TabsTrigger :value="isSearchActive ? '' : 'Academic'" :disabled="isSearchActive">
-            Academic
+          <TabsTrigger :value="isSearchActive ? '' : 'Academic'" :disabled="isSearchActive" class="flex items-center">
+            <Icon name="material-symbols:book" />
+            <div class="hidden sm:block ml-1">
+              Academic
+            </div>
           </TabsTrigger>
         </TabsList>
         <Input v-model="searchTerm" type="text" placeholder="Search..." class="float-right w-1/4" />

--- a/pages/cas/clubs/index.vue
+++ b/pages/cas/clubs/index.vue
@@ -27,19 +27,18 @@ const filteredClubs = computed(() => {
     return clubs
 
   // ignore capitalization
-  const regex = new RegExp(searchTerm.value, 'i')
+  const lowerCaseSearchTerm = searchTerm.value.toLowerCase()
 
   // return zh/en name match the search term
   return Object.entries(clubs).reduce((acc, [category]) => {
     acc[category as ClubCategoryKey] = allClubs.value.filter(club =>
       club.groups.some((group: Groups) =>
-        (group.C_NameC as string).match(regex) || (group.C_NameE as string).match(regex),
+        (group.C_NameC as string).toLowerCase().includes(lowerCaseSearchTerm) || (group.C_NameE as string).toLowerCase().includes(lowerCaseSearchTerm),
       ),
     )
     return acc
   }, {} as Clubs)
-},
-)
+})
 
 const isSearchActive = computed(() => searchTerm.value !== '')
 </script>

--- a/pages/cas/clubs/index.vue
+++ b/pages/cas/clubs/index.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
+import { Input } from '@/components/ui/input'
 import TabsList from '@/components/ui/tabs/TabsList.vue'
 import Tabs from '@/components/ui/tabs/Tabs.vue'
 import TabsContent from '@/components/ui/tabs/TabsContent.vue'
 import TabsTrigger from '@/components/ui/tabs/TabsTrigger.vue'
 import json from '@/content/clubs.json'
 
-import type { ClubCategoryKey, Clubs } from '@/content/clubs'
+import type { ClubCategoryKey, Clubs, Groups } from '@/content/clubs'
 import ClubCard from '@/components/custom/club-card.vue'
 
 const clubs: Clubs = json as Clubs
@@ -16,29 +17,55 @@ definePageMeta({
 })
 
 const categories = (['Sports', 'Service', 'Arts', 'Life', 'Academic'] as const).map(c => c as ClubCategoryKey)
+
+const searchTerm = ref('')
+const allClubs = computed(() => Object.values(clubs).flat())
+
+const filteredClubs = computed(() => {
+  // return all clubs if no search term
+  if (!searchTerm.value)
+    return clubs
+
+  // ignore capitalization
+  const regex = new RegExp(searchTerm.value, 'i')
+
+  // return zh/en name match the search term
+  return Object.entries(clubs).reduce((acc, [category]) => {
+    acc[category as ClubCategoryKey] = allClubs.value.filter(club =>
+      club.groups.some((group: Groups) =>
+        (group.C_NameC as string).match(regex) || (group.C_NameE as string).match(regex),
+      ),
+    )
+    return acc
+  }, {} as Clubs)
+},
+)
+
+const isSearchActive = computed(() => searchTerm.value !== '')
 </script>
 
 <template>
   <div>
-    <Tabs class="h-full space-y-6" default-value="Sports">
-      <div class="space-between flex items-center">
+    <Tabs class="h-full space-y-6" :value="isSearchActive ? '' : undefined" :default-value="isSearchActive ? '' : 'Sports'">
+      <div class="flex flex-col md:flex-row md:items-center md:justify-between">
         <TabsList>
-          <TabsTrigger value="Sports">
+          <TabsTrigger :value="isSearchActive ? '' : 'Sports'" :disabled="isSearchActive">
             Sports
           </TabsTrigger>
-          <TabsTrigger value="Service">
+          <TabsTrigger :value="isSearchActive ? '' : 'Service'" :disabled="isSearchActive">
             Service
           </TabsTrigger>
-          <TabsTrigger value="Arts">
+          <TabsTrigger :value="isSearchActive ? '' : 'Arts'" :disabled="isSearchActive">
             Arts
           </TabsTrigger>
-          <TabsTrigger value="Life">
+          <TabsTrigger :value="isSearchActive ? '' : 'Life'" :disabled="isSearchActive">
             Life
           </TabsTrigger>
-          <TabsTrigger value="Academic">
+          <TabsTrigger :value="isSearchActive ? '' : 'Academic'" :disabled="isSearchActive">
             Academic
           </TabsTrigger>
         </TabsList>
+        <Input v-model="searchTerm" type="text" placeholder="Search..." class="float-right w-1/4" />
       </div>
       <TabsContent
         v-for="i in categories"
@@ -47,7 +74,7 @@ const categories = (['Sports', 'Service', 'Arts', 'Life', 'Academic'] as const).
         class="border-none p-0 outline-none"
       >
         <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-          <ClubCard v-for="j in clubs[i]" :key="j.groups[0].C_NameE" :club="j" />
+          <ClubCard v-for="j in filteredClubs[i]" :key="j.groups[0].C_NameE" :club="j" />
         </div>
       </TabsContent>
     </Tabs>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,9 @@ module.exports = {
   safelist: ['dark'],
 
   theme: {
+    screens: {
+      ssm: '500px',
+    },
     container: {
       center: true,
       padding: '2rem',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,9 +6,6 @@ module.exports = {
   safelist: ['dark'],
 
   theme: {
-    screens: {
-      ssm: '500px',
-    },
     container: {
       center: true,
       padding: '2rem',


### PR DESCRIPTION
This PR contains a brand new feature which allows user to search clubs in `/cas/club` via its English or Chinese name while ignoring its capitalization. While there's `searchTerm` in the search box, Tabs will be disabled.

Such actions will be processed within user's browser without contacting the server.

Other project: #485 

## Known Issue

- [x] (Fixed) `*` and `\` may trigger 500 error page becuz of the usage of `regex`