### PR TITLE
fix(clubList): ignore spaces in empty description after processed with `cleanHTML`

### DIFF
--- a/pages/cas/clubs/[id].vue
+++ b/pages/cas/clubs/[id].vue
@@ -28,8 +28,11 @@ let hasDescriptionC = false
 let Description_C = ''
 
 if (filteredClubs[0] && filteredClubs[0].groups[0].C_DescriptionC) {
-  Description_C = cleanHTML(filteredClubs[0].groups[0].C_DescriptionC)
-  hasDescriptionC = true
+  const tempDescription = cleanHTML(filteredClubs[0].groups[0].C_DescriptionC)
+  if (tempDescription.trim() !== '') {
+    Description_C = tempDescription
+    hasDescriptionC = true
+  }
 }
 
 // This page requires login

--- a/pages/cas/clubs/[id].vue
+++ b/pages/cas/clubs/[id].vue
@@ -74,7 +74,7 @@ definePageMeta({
           </Card>
           <Card class="xl:w-1/4 w-full xl:ml-2">
             <CardHeader>
-              <CardTitle class="flex items-center gap-x-1">
+              <CardTitle class="flex items-center h-min gap-x-1">
                 社团属性
               </CardTitle>
               <CardDescription class="flex items-center">


### PR DESCRIPTION
Just a minor fix. You can see the difference on Student Union's page

Also, it fixed a [minor issue](https://github.com/Computerization/Enspire/issues/485#issuecomment-1983481167)

Related project: #485